### PR TITLE
Refactor StoreManager and decouple extension fetching logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3522,6 +3522,7 @@ dependencies = [
  "quelle_export",
  "quelle_storage",
  "quelle_store",
+ "quelle_types",
  "reqwest",
  "semver",
  "serde",
@@ -3566,9 +3567,11 @@ dependencies = [
  "chrono",
  "clap",
  "ego-tree",
+ "eyre",
  "ghostwire",
  "headless_chrome",
  "html5ever",
+ "quelle_types",
  "reqwest",
  "scraper",
  "serde_json",
@@ -3591,6 +3594,7 @@ dependencies = [
  "eyre",
  "quelle_engine",
  "quelle_storage",
+ "quelle_types",
  "regex",
  "scraper",
  "tempfile",
@@ -3624,7 +3628,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "eyre",
- "quelle_engine",
+ "quelle_types",
  "serde",
  "serde_json",
  "sha2",
@@ -3647,6 +3651,7 @@ dependencies = [
  "futures",
  "git2",
  "quelle_engine",
+ "quelle_types",
  "reqwest",
  "semver",
  "serde",
@@ -3659,6 +3664,13 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "walkdir",
+]
+
+[[package]]
+name = "quelle_types"
+version = "0.1.0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ url = "2.5.7"
 regex = "1.11.3"
 semver = "1.0.27"
 serde = "1.0"
+quelle_types = { path = "crates/types" }
 serde_json = "1"
 
 # Protobuf related dependencies

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -18,6 +18,7 @@ quelle_engine = { path = "../engine" }
 quelle_store = { path = "../store", features = ["git", "github"] }
 quelle_storage = { path = "../storage" }
 quelle_export = { path = "../export" }
+quelle_types = { path = "../types" }
 
 clap = { version = "4.5.48", features = ["derive"] }
 directories = "6.0"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -14,7 +14,7 @@ github = ["quelle_store/github"]
 pdf = ["quelle_export/pdf"]
 
 [dependencies]
-quelle_engine = { path = "../engine" }
+quelle_engine = { path = "../engine", features = ["cli"] }
 quelle_store = { path = "../store", features = ["git", "github"] }
 quelle_storage = { path = "../storage" }
 quelle_export = { path = "../export" }

--- a/crates/cli/src/commands/fetch.rs
+++ b/crates/cli/src/commands/fetch.rs
@@ -11,7 +11,7 @@ use quelle_storage::{
 };
 use quelle_store::StoreManager;
 use std::io::Cursor;
-use tracing::{error, info, warn};
+use tracing::{error, warn};
 use url::Url;
 
 use crate::cli::FetchCommands;
@@ -89,47 +89,10 @@ async fn handle_fetch_novel(
         return Ok(());
     }
 
-    let (extension_id, _store_name) =
-        match find_extension_for_url(url.as_ref(), store_manager).await? {
-            Some(ext) => ext,
-            None => {
-                eprintln!("Error: No compatible extension found for: {}", url);
-                return Ok(());
-            }
-        };
-
-    if store_manager.get_installed(&extension_id).await?.is_none() {
-        println!("Installing extension {}...", extension_id);
-        match store_manager.install(&extension_id, None, None).await {
-            Ok(installed) => {
-                println!("Installed {} v{}.", installed.name, installed.version);
-            }
-            Err(e) => {
-                eprintln!("Error: Failed to install {}: {}", extension_id, e);
-                return Err(e.into());
-            }
-        }
-    }
-
-    let installed = match store_manager.get_installed(&extension_id).await? {
-        Some(ext) => ext,
-        None => {
-            eprintln!("Error: Extension {} not found after install.", extension_id);
-            return Ok(());
-        }
-    };
-
     let engine = create_extension_engine()?;
 
     println!("Fetching novel...");
-    match fetch_novel_with_extension(
-        &installed,
-        store_manager.registry_store(),
-        url.as_ref(),
-        &engine,
-    )
-    .await
-    {
+    match store_manager.fetch_novel(&engine, url.as_ref()).await {
         Ok(novel) => {
             println!("title: {}", novel.title);
             println!("authors: {}", novel.authors.join(", "));
@@ -155,7 +118,7 @@ async fn handle_fetch_novel(
         }
         Err(e) => {
             eprintln!("Error: Failed to fetch novel: {}", e);
-            return Err(e);
+            return Err(e.into());
         }
     }
 
@@ -173,49 +136,12 @@ async fn handle_fetch_chapter(
         return Ok(());
     }
 
-    let (extension_id, _store_name) =
-        match find_extension_for_url(url.as_ref(), store_manager).await? {
-            Some(ext) => ext,
-            None => {
-                eprintln!("Error: No compatible extension found for: {}", url);
-                return Ok(());
-            }
-        };
-
-    if store_manager.get_installed(&extension_id).await?.is_none() {
-        println!("Installing extension {}...", extension_id);
-        match store_manager.install(&extension_id, None, None).await {
-            Ok(installed) => {
-                println!("Installed {} v{}.", installed.name, installed.version);
-            }
-            Err(e) => {
-                eprintln!("Error: Failed to install {}: {}", extension_id, e);
-                return Err(e.into());
-            }
-        }
-    }
-
-    let installed = match store_manager.get_installed(&extension_id).await? {
-        Some(ext) => ext,
-        None => {
-            eprintln!("Error: Extension {} not found after install.", extension_id);
-            return Ok(());
-        }
-    };
-
     let engine = create_extension_engine()?;
-    let chapter = match fetch_chapter_with_extension(
-        &installed,
-        store_manager.registry_store(),
-        url.as_ref(),
-        &engine,
-    )
-    .await
-    {
+    let chapter = match store_manager.fetch_chapter(&engine, url.as_ref()).await {
         Ok(ch) => ch,
         Err(e) => {
             eprintln!("Error: Failed to fetch chapter: {}", e);
-            return Err(e);
+            return Err(e.into());
         }
     };
 
@@ -241,8 +167,11 @@ async fn handle_fetch_chapter(
                 }
             };
             if let Some(novel_summary) = novels.iter().find(|n| n.title == novel.title) {
+                let content = ChapterContent {
+                    data: chapter.data.clone(),
+                };
                 match storage
-                    .store_chapter_content(&novel_summary.id, volume.index, url.as_ref(), &chapter)
+                    .store_chapter_content(&novel_summary.id, volume.index, url.as_ref(), &content)
                     .await
                 {
                     Ok(_) => {
@@ -283,7 +212,7 @@ pub async fn handle_fetch_chapters(
     }
 
     // Resolve novel + its storage ID from either a URL or a direct novel ID.
-    let (novel, novel_storage_id) = if novel_id.starts_with("http") {
+    let (_novel, novel_storage_id) = if novel_id.starts_with("http") {
         let novel = match storage.find_novel_by_url(&novel_id).await? {
             Some(novel) => novel,
             None => {
@@ -311,14 +240,6 @@ pub async fn handle_fetch_chapters(
         (novel, id)
     };
 
-    let installed = match find_and_install_extension_for_url(&novel.url, store_manager).await {
-        Ok(ext) => ext,
-        Err(e) => {
-            error!("Failed to find/install extension: {}", e);
-            return Err(e);
-        }
-    };
-
     let mut chapters = storage.list_chapters(&novel_storage_id).await?;
     let original_count = chapters.len();
 
@@ -343,13 +264,9 @@ pub async fn handle_fetch_chapters(
             continue;
         }
 
-        let chapter_content = match fetch_chapter_with_extension(
-            &installed,
-            store_manager.registry_store(),
-            &chapter_info.chapter_url,
-            engine,
-        )
-        .await
+        let chapter_content = match store_manager
+            .fetch_chapter(engine, &chapter_info.chapter_url)
+            .await
         {
             Ok(content) => content,
             Err(e) => {
@@ -418,97 +335,6 @@ async fn handle_fetch_all(
 
     println!("Done.");
     Ok(())
-}
-
-/// Find an extension that can handle the given URL.
-pub async fn find_extension_for_url(
-    url: &str,
-    store_manager: &StoreManager,
-) -> Result<Option<(String, String)>> {
-    store_manager
-        .find_extension_for_url(url)
-        .await
-        .map_err(|e| eyre::eyre!("Failed to find extension for URL: {}", e))
-}
-
-/// Find and, if necessary, install an extension that can handle the given URL.
-pub async fn find_and_install_extension_for_url(
-    url: &str,
-    store_manager: &mut StoreManager,
-) -> Result<quelle_store::models::InstalledExtension> {
-    match find_extension_for_url(url, store_manager).await? {
-        Some((extension_id, _store_name)) => {
-            if let Some(installed) = store_manager.get_installed(&extension_id).await? {
-                return Ok(installed);
-            }
-
-            println!("Installing extension {}...", extension_id);
-            match store_manager.install(&extension_id, None, None).await {
-                Ok(installed) => {
-                    info!("Installed {} v{}.", installed.name, installed.version);
-                    Ok(installed)
-                }
-                Err(e) => {
-                    error!("Failed to install {}: {}", extension_id, e);
-                    Err(e.into())
-                }
-            }
-        }
-        None => Err(eyre::eyre!(
-            "No extension found for URL: {}\nTry adding more extension stores with: quelle store add",
-            url
-        )),
-    }
-}
-
-/// Fetch novel information using an installed extension and the provided engine.
-pub async fn fetch_novel_with_extension(
-    installed: &quelle_store::models::InstalledExtension,
-    registry: &dyn quelle_store::registry::InstallRegistry,
-    url: &str,
-    engine: &ExtensionEngine,
-) -> Result<quelle_storage::Novel> {
-    let wasm_bytes = registry.get_extension_wasm_bytes(&installed.id).await?;
-    let runner = engine.new_runner_from_bytes(&wasm_bytes).await?;
-    let (_, result) = runner.fetch_novel_info(url).await?;
-
-    match result {
-        Ok(novel) => Ok(novel),
-        Err(wit_error) => {
-            let chain = wit_error
-                .frames
-                .iter()
-                .map(|f| f.message.as_str())
-                .collect::<Vec<_>>()
-                .join(": ");
-            Err(eyre::eyre!("Extension error: {}", chain))
-        }
-    }
-}
-
-/// Fetch chapter content using an installed extension and the provided engine.
-pub async fn fetch_chapter_with_extension(
-    installed: &quelle_store::models::InstalledExtension,
-    registry: &dyn quelle_store::registry::InstallRegistry,
-    url: &str,
-    engine: &ExtensionEngine,
-) -> Result<ChapterContent> {
-    let wasm_bytes = registry.get_extension_wasm_bytes(&installed.id).await?;
-    let runner = engine.new_runner_from_bytes(&wasm_bytes).await?;
-    let (_, result) = runner.fetch_chapter(url).await?;
-
-    match result {
-        Ok(chapter) => Ok(chapter),
-        Err(wit_error) => {
-            let chain = wit_error
-                .frames
-                .iter()
-                .map(|f| f.message.as_str())
-                .collect::<Vec<_>>()
-                .join(": ");
-            Err(eyre::eyre!("Extension error: {}", chain))
-        }
-    }
 }
 
 async fn fetch_and_store_asset(

--- a/crates/cli/src/commands/fetch.rs
+++ b/crates/cli/src/commands/fetch.rs
@@ -92,7 +92,7 @@ async fn handle_fetch_novel(
     let engine = create_extension_engine()?;
 
     println!("Fetching novel...");
-    match store_manager.fetch_novel(&engine, url.as_ref()).await {
+    match crate::engine::fetch_novel(&engine, store_manager, url.as_ref()).await {
         Ok(novel) => {
             println!("title: {}", novel.title);
             println!("authors: {}", novel.authors.join(", "));
@@ -137,7 +137,7 @@ async fn handle_fetch_chapter(
     }
 
     let engine = create_extension_engine()?;
-    let chapter = match store_manager.fetch_chapter(&engine, url.as_ref()).await {
+    let chapter = match crate::engine::fetch_chapter(&engine, store_manager, url.as_ref()).await {
         Ok(ch) => ch,
         Err(e) => {
             eprintln!("Error: Failed to fetch chapter: {}", e);
@@ -147,10 +147,20 @@ async fn handle_fetch_chapter(
 
     println!("chapters: {} chars fetched", chapter.data.len());
 
-    let novel = match storage.find_novel_by_url(url.as_ref()).await {
-        Ok(Some(novel)) => novel,
+    // Look up the novel ID directly from the URL — no title-matching needed.
+    let novel_id = match storage.find_novel_id_by_url(url.as_ref()).await {
+        Ok(Some(id)) => id,
         _ => {
             println!("Chapter not saved: novel not in library.");
+            return Ok(());
+        }
+    };
+
+    // We still need the novel structure to find the right volume index.
+    let novel = match storage.get_novel(&novel_id).await {
+        Ok(Some(novel)) => novel,
+        _ => {
+            println!("Chapter not saved: could not load novel from library.");
             return Ok(());
         }
     };
@@ -158,29 +168,19 @@ async fn handle_fetch_chapter(
     let mut saved = false;
     for volume in &novel.volumes {
         if volume.chapters.iter().any(|ch| ch.url == url.to_string()) {
-            let filter = quelle_storage::types::NovelFilter { source_ids: vec![] };
-            let novels = match storage.list_novels(&filter).await {
-                Ok(novels) => novels,
-                Err(e) => {
-                    eprintln!("Error: Failed to list novels: {}", e);
-                    break;
-                }
+            let content = ChapterContent {
+                data: chapter.data.clone(),
             };
-            if let Some(novel_summary) = novels.iter().find(|n| n.title == novel.title) {
-                let content = ChapterContent {
-                    data: chapter.data.clone(),
-                };
-                match storage
-                    .store_chapter_content(&novel_summary.id, volume.index, url.as_ref(), &content)
-                    .await
-                {
-                    Ok(_) => {
-                        println!("Saved chapter content to library.");
-                        saved = true;
-                    }
-                    Err(e) => {
-                        eprintln!("Error: Failed to save chapter: {}", e);
-                    }
+            match storage
+                .store_chapter_content(&novel_id, volume.index, url.as_ref(), &content)
+                .await
+            {
+                Ok(_) => {
+                    println!("Saved chapter content to library.");
+                    saved = true;
+                }
+                Err(e) => {
+                    eprintln!("Error: Failed to save chapter: {}", e);
                 }
             }
             break;
@@ -213,20 +213,20 @@ pub async fn handle_fetch_chapters(
 
     // Resolve novel + its storage ID from either a URL or a direct novel ID.
     let (_novel, novel_storage_id) = if novel_id.starts_with("http") {
-        let novel = match storage.find_novel_by_url(&novel_id).await? {
+        let storage_id = match storage.find_novel_id_by_url(&novel_id).await? {
+            Some(id) => id,
+            None => {
+                eprintln!("Not found: {}", novel_id);
+                return Ok(());
+            }
+        };
+        let novel = match storage.get_novel(&storage_id).await? {
             Some(novel) => novel,
             None => {
                 eprintln!("Not found: {}", novel_id);
                 return Ok(());
             }
         };
-        let filter = quelle_storage::types::NovelFilter { source_ids: vec![] };
-        let novels = storage.list_novels(&filter).await?;
-        let storage_id = novels
-            .iter()
-            .find(|n| n.title == novel.title)
-            .map(|n| n.id.clone())
-            .unwrap_or_else(|| NovelId::new(novel_id.clone()));
         (novel, storage_id)
     } else {
         let id = NovelId::new(novel_id.clone());
@@ -264,17 +264,17 @@ pub async fn handle_fetch_chapters(
             continue;
         }
 
-        let chapter_content = match store_manager
-            .fetch_chapter(engine, &chapter_info.chapter_url)
-            .await
-        {
-            Ok(content) => content,
-            Err(e) => {
-                error!("Failed to fetch '{}': {}", chapter_info.chapter_title, e);
-                failed_count += 1;
-                continue;
-            }
-        };
+        let chapter_content =
+            match crate::engine::fetch_chapter(engine, store_manager, &chapter_info.chapter_url)
+                .await
+            {
+                Ok(content) => content,
+                Err(e) => {
+                    error!("Failed to fetch '{}': {}", chapter_info.chapter_title, e);
+                    failed_count += 1;
+                    continue;
+                }
+            };
 
         let content = ChapterContent {
             data: chapter_content.data,

--- a/crates/cli/src/commands/library.rs
+++ b/crates/cli/src/commands/library.rs
@@ -415,16 +415,10 @@ async fn sync_single_novel(
         .await?
         .ok_or_else(|| eyre::eyre!("Novel not found: {}", novel_id.as_str()))?;
 
-    let extension = find_and_install_extension_for_url(&stored_novel.url, store_manager).await?;
-
     let engine = create_extension_engine()?;
-    let fresh_novel = fetch_novel_with_extension(
-        &extension,
-        store_manager.registry_store(),
-        &stored_novel.url,
-        &engine,
-    )
-    .await?;
+    let fresh_novel = store_manager
+        .fetch_novel(&engine, &stored_novel.url)
+        .await?;
 
     let stored_chapters = storage.list_chapters(novel_id).await?;
     let stored_chapter_urls: std::collections::HashSet<_> =
@@ -452,13 +446,6 @@ async fn update_single_novel(
     store_manager: &mut StoreManager,
     engine: &ExtensionEngine,
 ) -> Result<u32> {
-    let stored_novel = storage
-        .get_novel(novel_id)
-        .await?
-        .ok_or_else(|| eyre::eyre!("Novel not found: {}", novel_id.as_str()))?;
-
-    let extension = find_and_install_extension_for_url(&stored_novel.url, store_manager).await?;
-
     let chapters = storage.list_chapters(novel_id).await?;
     let mut downloaded_count = 0u32;
     let mut failed_count = 0u32;
@@ -466,13 +453,9 @@ async fn update_single_novel(
     for chapter_info in chapters {
         if !chapter_info.has_content() {
             tracing::info!("Downloading chapter: {}", chapter_info.chapter_title);
-            match fetch_chapter_with_extension(
-                &extension,
-                store_manager.registry_store(),
-                &chapter_info.chapter_url,
-                engine,
-            )
-            .await
+            match store_manager
+                .fetch_chapter(engine, &chapter_info.chapter_url)
+                .await
             {
                 Ok(chapter_content) => {
                     let content = ChapterContent {
@@ -593,8 +576,3 @@ async fn handle_library_stats(storage: &FilesystemStorage) -> Result<()> {
     }
     Ok(())
 }
-
-// Re-export helpers from fetch.rs that library.rs uses internally.
-use crate::commands::fetch::{
-    fetch_chapter_with_extension, fetch_novel_with_extension, find_and_install_extension_for_url,
-};

--- a/crates/cli/src/commands/library.rs
+++ b/crates/cli/src/commands/library.rs
@@ -416,9 +416,7 @@ async fn sync_single_novel(
         .ok_or_else(|| eyre::eyre!("Novel not found: {}", novel_id.as_str()))?;
 
     let engine = create_extension_engine()?;
-    let fresh_novel = store_manager
-        .fetch_novel(&engine, &stored_novel.url)
-        .await?;
+    let fresh_novel = crate::engine::fetch_novel(&engine, store_manager, &stored_novel.url).await?;
 
     let stored_chapters = storage.list_chapters(novel_id).await?;
     let stored_chapter_urls: std::collections::HashSet<_> =
@@ -453,8 +451,7 @@ async fn update_single_novel(
     for chapter_info in chapters {
         if !chapter_info.has_content() {
             tracing::info!("Downloading chapter: {}", chapter_info.chapter_title);
-            match store_manager
-                .fetch_chapter(engine, &chapter_info.chapter_url)
+            match crate::engine::fetch_chapter(engine, store_manager, &chapter_info.chapter_url)
                 .await
             {
                 Ok(chapter_content) => {

--- a/crates/cli/src/commands/search.rs
+++ b/crates/cli/src/commands/search.rs
@@ -1,8 +1,8 @@
 //! Search command handlers for finding novels across installed extension sources.
 
 use eyre::Result;
-use quelle_engine::bindings::quelle::extension::novel::BasicNovel;
 use quelle_store::{SearchQuery, StoreManager};
+use quelle_types::BasicNovel;
 use tracing::warn;
 
 #[allow(clippy::too_many_arguments)]

--- a/crates/cli/src/engine.rs
+++ b/crates/cli/src/engine.rs
@@ -1,50 +1,14 @@
 //! Extension engine construction helpers.
+//!
+//! Re-exports [`Executor`] and [`create_engine`] from `quelle_engine` for use
+//! within this crate, plus a convenience no-argument wrapper for call sites
+//! that do not need to select an executor explicitly.
 
-use eyre::Result;
-use quelle_engine::{
-    ExtensionEngine,
-    http::{GhostwireExecutor, HeadlessChromeExecutor, ReqwestExecutor},
-};
+pub use quelle_engine::{Executor, create_engine as create_extension_engine_with_executor};
 
-#[derive(Debug, Clone, Default, clap::ValueEnum)]
-pub enum Executor {
-    #[default]
-    Ghostwire,
-    Chrome,
-    Reqwest,
-}
-
-pub fn create_extension_engine() -> Result<ExtensionEngine> {
+/// Create an [`quelle_engine::ExtensionEngine`] using the default executor.
+pub fn create_extension_engine() -> eyre::Result<quelle_engine::ExtensionEngine> {
     create_extension_engine_with_executor(Executor::default())
-}
-
-pub fn create_extension_engine_with_executor(executor: Executor) -> Result<ExtensionEngine> {
-    match executor {
-        Executor::Ghostwire => create_ghostwire_engine(),
-        Executor::Chrome => try_create_chrome_engine().or_else(|e| {
-            tracing::warn!("Failed to create Chrome executor, falling back to Ghostwire: {e}");
-            create_ghostwire_engine()
-        }),
-        Executor::Reqwest => create_reqwest_engine(),
-    }
-}
-
-fn create_ghostwire_engine() -> Result<ExtensionEngine> {
-    tracing::info!("Using Ghostwire executor for extensions");
-    let executor = std::sync::Arc::new(GhostwireExecutor::new().map_err(eyre::Report::from)?);
-    ExtensionEngine::new(executor).map_err(eyre::Report::from)
-}
-
-fn try_create_chrome_engine() -> Result<ExtensionEngine> {
-    tracing::info!("Using HeadlessChrome executor for extensions");
-    let executor = std::sync::Arc::new(HeadlessChromeExecutor::new());
-    ExtensionEngine::new(executor).map_err(eyre::Report::from)
-}
-
-fn create_reqwest_engine() -> Result<ExtensionEngine> {
-    tracing::info!("Using Reqwest executor for extensions");
-    let executor = std::sync::Arc::new(ReqwestExecutor::new());
-    ExtensionEngine::new(executor).map_err(eyre::Report::from)
 }
 
 #[cfg(test)]

--- a/crates/cli/src/engine.rs
+++ b/crates/cli/src/engine.rs
@@ -3,12 +3,98 @@
 //! Re-exports [`Executor`] and [`create_engine`] from `quelle_engine` for use
 //! within this crate, plus a convenience no-argument wrapper for call sites
 //! that do not need to select an executor explicitly.
+//!
+//! Also provides free async functions [`fetch_novel`] and [`fetch_chapter`] that
+//! wire together the store (extension management) and the engine (content execution)
+//! without coupling the two crates to each other.
 
 pub use quelle_engine::{Executor, create_engine as create_extension_engine_with_executor};
 
 /// Create an [`quelle_engine::ExtensionEngine`] using the default executor.
 pub fn create_extension_engine() -> eyre::Result<quelle_engine::ExtensionEngine> {
     create_extension_engine_with_executor(Executor::default())
+}
+
+/// Find/install the right extension for `url`, then run it to fetch novel metadata.
+///
+/// This replaces the former `StoreManager::fetch_novel` method, keeping extension
+/// management (`StoreManager`) and content execution (`ExtensionEngine`) decoupled.
+pub async fn fetch_novel(
+    engine: &quelle_engine::ExtensionEngine,
+    store_manager: &mut quelle_store::StoreManager,
+    url: &str,
+) -> eyre::Result<quelle_types::Novel> {
+    let installed = store_manager
+        .find_and_install_for_url(url)
+        .await
+        .map_err(|e| eyre::eyre!("{}", e))?;
+
+    let wasm_bytes = store_manager
+        .registry_store()
+        .get_extension_wasm_bytes(&installed.id)
+        .await
+        .map_err(|e| eyre::eyre!("{}", e))?;
+
+    let runner = engine
+        .new_runner_from_bytes(&wasm_bytes)
+        .await
+        .map_err(|e| eyre::eyre!("{}", e))?;
+
+    let (_, result) = runner
+        .fetch_novel_info(url)
+        .await
+        .map_err(|e| eyre::eyre!("{}", e))?;
+
+    result.map_err(|wit_err| {
+        let chain = wit_err
+            .frames
+            .iter()
+            .map(|f| f.message.as_str())
+            .collect::<Vec<_>>()
+            .join(": ");
+        eyre::eyre!("Extension error: {}", chain)
+    })
+}
+
+/// Find/install the right extension for `url`, then run it to fetch chapter content.
+///
+/// This replaces the former `StoreManager::fetch_chapter` method, keeping extension
+/// management (`StoreManager`) and content execution (`ExtensionEngine`) decoupled.
+pub async fn fetch_chapter(
+    engine: &quelle_engine::ExtensionEngine,
+    store_manager: &mut quelle_store::StoreManager,
+    url: &str,
+) -> eyre::Result<quelle_types::ChapterContent> {
+    let installed = store_manager
+        .find_and_install_for_url(url)
+        .await
+        .map_err(|e| eyre::eyre!("{}", e))?;
+
+    let wasm_bytes = store_manager
+        .registry_store()
+        .get_extension_wasm_bytes(&installed.id)
+        .await
+        .map_err(|e| eyre::eyre!("{}", e))?;
+
+    let runner = engine
+        .new_runner_from_bytes(&wasm_bytes)
+        .await
+        .map_err(|e| eyre::eyre!("{}", e))?;
+
+    let (_, result) = runner
+        .fetch_chapter(url)
+        .await
+        .map_err(|e| eyre::eyre!("{}", e))?;
+
+    result.map_err(|wit_err| {
+        let chain = wit_err
+            .frames
+            .iter()
+            .map(|f| f.message.as_str())
+            .collect::<Vec<_>>()
+            .join(": ");
+        eyre::eyre!("Extension error: {}", chain)
+    })
 }
 
 #[cfg(test)]

--- a/crates/cli/src/resolve.rs
+++ b/crates/cli/src/resolve.rs
@@ -30,11 +30,8 @@ pub async fn resolve_novel_id(input: &str, storage: &dyn BookStorage) -> Result<
 
     // Try URL lookup.
     if let Ok(_url) = Url::parse(input) {
-        if let Ok(Some(found_novel)) = storage.find_novel_by_url(input).await {
-            let novels = storage.list_novels(&NovelFilter::default()).await?;
-            if let Some(novel_summary) = novels.iter().find(|n| n.title == found_novel.title) {
-                return Ok(Some(novel_summary.id.clone()));
-            }
+        if let Ok(Some(novel_id)) = storage.find_novel_id_by_url(input).await {
+            return Ok(Some(novel_id));
         }
     }
 

--- a/crates/dev/Cargo.toml
+++ b/crates/dev/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-quelle_engine = { path = "../engine" }
+quelle_engine = { path = "../engine", features = ["cli"] }
 
 clap = { version = "4.5.48", features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }

--- a/crates/dev/src/server/mod.rs
+++ b/crates/dev/src/server/mod.rs
@@ -14,7 +14,7 @@ use crate::http_caching::CachingHttpExecutor;
 use crate::server::commands::handle;
 use crate::utils::{find_extension_path, find_project_root};
 
-pub use crate::utils::Executor;
+pub use quelle_engine::Executor;
 use quelle_engine::ExtensionEngine;
 use quelle_engine::http::{GhostwireExecutor, HeadlessChromeExecutor, ReqwestExecutor};
 

--- a/crates/dev/src/utils/mod.rs
+++ b/crates/dev/src/utils/mod.rs
@@ -6,17 +6,8 @@ use std::path::PathBuf;
 pub mod fs;
 pub mod validation;
 
-/// The HTTP executor backend to use for extension requests.
-#[derive(Debug, Clone, Default, clap::ValueEnum)]
-pub enum Executor {
-    /// Ghostwire cloud-scraper — bypasses Cloudflare and other bot protections (default)
-    #[default]
-    Ghostwire,
-    /// Headless Chrome — handles JavaScript-heavy sites; falls back to Ghostwire on failure
-    Chrome,
-    /// Plain reqwest — fast and lightweight, no JS support
-    Reqwest,
-}
+// Re-export the executor type from quelle_engine so dev tooling uses the same definition.
+pub use quelle_engine::Executor;
 
 /// Find the extension directory for a given extension name
 pub fn find_extension_path(extension_name: &str) -> Result<PathBuf> {

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2024"
 
 [dependencies]
 wasmtime.workspace = true
+quelle_types = { path = "../types" }
+eyre.workspace = true
 reqwest = { workspace = true }
 headless_chrome = "1.0.21"
 ghostwire.workspace = true

--- a/crates/engine/Cargo.toml
+++ b/crates/engine/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+# Enables clap::ValueEnum derive on the Executor enum, for use by CLI binaries.
+cli = ["dep:clap"]
+
 [dependencies]
 wasmtime.workspace = true
 quelle_types = { path = "../types" }
@@ -16,7 +20,7 @@ async-trait = "0.1.80"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1.0"
 base64 = "0.22.1"
-clap = { version = "4.5.11", features = ["derive"] }
+clap = { version = "4.5.11", features = ["derive"], optional = true }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 thiserror.workspace = true

--- a/crates/engine/src/executor.rs
+++ b/crates/engine/src/executor.rs
@@ -6,7 +6,8 @@ use eyre::Result;
 use std::sync::Arc;
 
 /// The HTTP executor backend to use for extension requests.
-#[derive(Debug, Clone, Default, clap::ValueEnum)]
+#[derive(Debug, Clone, Default)]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 pub enum Executor {
     /// Ghostwire cloud-scraper — bypasses Cloudflare and other bot protections (default)
     #[default]

--- a/crates/engine/src/executor.rs
+++ b/crates/engine/src/executor.rs
@@ -1,0 +1,45 @@
+//! HTTP executor selection.
+
+use crate::ExtensionEngine;
+use crate::http::{GhostwireExecutor, HeadlessChromeExecutor, ReqwestExecutor};
+use eyre::Result;
+use std::sync::Arc;
+
+/// The HTTP executor backend to use for extension requests.
+#[derive(Debug, Clone, Default, clap::ValueEnum)]
+pub enum Executor {
+    /// Ghostwire cloud-scraper — bypasses Cloudflare and other bot protections (default)
+    #[default]
+    Ghostwire,
+    /// Headless Chrome — handles JavaScript-heavy sites; falls back to Ghostwire on failure
+    Chrome,
+    /// Plain reqwest — fast and lightweight, no JS support
+    Reqwest,
+}
+
+/// Create an `ExtensionEngine` using the given executor choice.
+pub fn create_engine(executor: Executor) -> Result<ExtensionEngine> {
+    match executor {
+        Executor::Ghostwire => {
+            tracing::info!("Using Ghostwire executor");
+            let e = Arc::new(GhostwireExecutor::new().map_err(eyre::Report::from)?);
+            ExtensionEngine::new(e).map_err(eyre::Report::from)
+        }
+        Executor::Chrome => create_chrome_engine().or_else(|err| {
+            tracing::warn!("Chrome executor failed, falling back to Ghostwire: {err}");
+            let e = Arc::new(GhostwireExecutor::new().map_err(eyre::Report::from)?);
+            ExtensionEngine::new(e).map_err(eyre::Report::from)
+        }),
+        Executor::Reqwest => {
+            tracing::info!("Using Reqwest executor");
+            let e = Arc::new(ReqwestExecutor::new());
+            ExtensionEngine::new(e).map_err(eyre::Report::from)
+        }
+    }
+}
+
+fn create_chrome_engine() -> Result<ExtensionEngine> {
+    tracing::info!("Using HeadlessChrome executor");
+    let e = Arc::new(HeadlessChromeExecutor::new());
+    ExtensionEngine::new(e).map_err(eyre::Report::from)
+}

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -155,7 +155,7 @@ impl<'a> ExtensionRunner<'a> {
         url: &str,
     ) -> error::Result<(Self, Result<quelle_types::Novel, wit_error::Error>)> {
         let (runner, result) = wrap_extension_method!(self, call_fetch_novel_info, url)?;
-        Ok((runner, result.map(novel_from_wit)))
+        Ok((runner, result.map(Into::into)))
     }
 
     /// Safe wrapper around [`Extension::fetch_chapter`].
@@ -164,7 +164,7 @@ impl<'a> ExtensionRunner<'a> {
         url: &str,
     ) -> error::Result<(Self, Result<quelle_types::ChapterContent, wit_error::Error>)> {
         let (runner, result) = wrap_extension_method!(self, call_fetch_chapter, url)?;
-        Ok((runner, result.map(chapter_content_from_wit)))
+        Ok((runner, result.map(Into::into)))
     }
 
     /// Safe wrapper around [`Extension::simple_search`].
@@ -173,7 +173,7 @@ impl<'a> ExtensionRunner<'a> {
         query: &SimpleSearchQuery,
     ) -> error::Result<(Self, Result<quelle_types::SearchResult, wit_error::Error>)> {
         let (runner, result) = wrap_extension_method!(self, call_simple_search, query)?;
-        Ok((runner, result.map(search_result_from_wit)))
+        Ok((runner, result.map(Into::into)))
     }
 
     /// Safe wrapper around [`Extension::complex_search`].
@@ -182,97 +182,111 @@ impl<'a> ExtensionRunner<'a> {
         query: &ComplexSearchQuery,
     ) -> error::Result<(Self, Result<quelle_types::SearchResult, wit_error::Error>)> {
         let (runner, result) = wrap_extension_method!(self, call_complex_search, query)?;
-        Ok((runner, result.map(search_result_from_wit)))
+        Ok((runner, result.map(Into::into)))
     }
 }
 
 // ---------------------------------------------------------------------------
-// Private WIT → quelle_types conversion functions
+// From trait implementations: WIT → quelle_types
 // ---------------------------------------------------------------------------
 
-fn novel_from_wit(w: bindings::quelle::extension::novel::Novel) -> quelle_types::Novel {
-    quelle_types::Novel {
-        url: w.url,
-        authors: w.authors,
-        title: w.title,
-        cover: w.cover,
-        description: w.description,
-        volumes: w.volumes.into_iter().map(volume_from_wit).collect(),
-        metadata: w.metadata.into_iter().map(metadata_from_wit).collect(),
-        status: novel_status_from_wit(w.status),
-        langs: w.langs,
+impl From<bindings::quelle::extension::novel::NovelStatus> for quelle_types::NovelStatus {
+    fn from(w: bindings::quelle::extension::novel::NovelStatus) -> Self {
+        use bindings::quelle::extension::novel::NovelStatus as WitStatus;
+        match w {
+            WitStatus::Ongoing => quelle_types::NovelStatus::Ongoing,
+            WitStatus::Hiatus => quelle_types::NovelStatus::Hiatus,
+            WitStatus::Completed => quelle_types::NovelStatus::Completed,
+            WitStatus::Stub => quelle_types::NovelStatus::Stub,
+            WitStatus::Dropped => quelle_types::NovelStatus::Dropped,
+            WitStatus::Unknown => quelle_types::NovelStatus::Unknown,
+        }
     }
 }
 
-fn volume_from_wit(w: bindings::quelle::extension::novel::Volume) -> quelle_types::Volume {
-    quelle_types::Volume {
-        name: w.name,
-        index: w.index,
-        chapters: w.chapters.into_iter().map(chapter_from_wit).collect(),
-    }
-}
-
-fn chapter_from_wit(w: bindings::quelle::extension::novel::Chapter) -> quelle_types::Chapter {
-    quelle_types::Chapter {
-        title: w.title,
-        index: w.index,
-        url: w.url,
-        updated_at: w.updated_at,
-    }
-}
-
-fn metadata_from_wit(w: bindings::quelle::extension::novel::Metadata) -> quelle_types::Metadata {
-    use bindings::quelle::extension::novel::Namespace as WitNs;
-    quelle_types::Metadata {
-        name: w.name,
-        value: w.value,
-        ns: match w.ns {
+impl From<bindings::quelle::extension::novel::Namespace> for quelle_types::Namespace {
+    fn from(w: bindings::quelle::extension::novel::Namespace) -> Self {
+        use bindings::quelle::extension::novel::Namespace as WitNs;
+        match w {
             WitNs::Dc => quelle_types::Namespace::Dc,
             WitNs::Opf => quelle_types::Namespace::Opf,
-        },
-        others: w.others,
+        }
     }
 }
 
-fn novel_status_from_wit(
-    w: bindings::quelle::extension::novel::NovelStatus,
-) -> quelle_types::NovelStatus {
-    use bindings::quelle::extension::novel::NovelStatus as WitStatus;
-    match w {
-        WitStatus::Ongoing => quelle_types::NovelStatus::Ongoing,
-        WitStatus::Hiatus => quelle_types::NovelStatus::Hiatus,
-        WitStatus::Completed => quelle_types::NovelStatus::Completed,
-        WitStatus::Stub => quelle_types::NovelStatus::Stub,
-        WitStatus::Dropped => quelle_types::NovelStatus::Dropped,
-        WitStatus::Unknown => quelle_types::NovelStatus::Unknown,
+impl From<bindings::quelle::extension::novel::Chapter> for quelle_types::Chapter {
+    fn from(w: bindings::quelle::extension::novel::Chapter) -> Self {
+        quelle_types::Chapter {
+            title: w.title,
+            index: w.index,
+            url: w.url,
+            updated_at: w.updated_at,
+        }
     }
 }
 
-fn chapter_content_from_wit(
-    w: bindings::quelle::extension::novel::ChapterContent,
-) -> quelle_types::ChapterContent {
-    quelle_types::ChapterContent { data: w.data }
-}
-
-fn basic_novel_from_wit(
-    w: bindings::quelle::extension::novel::BasicNovel,
-) -> quelle_types::BasicNovel {
-    quelle_types::BasicNovel {
-        title: w.title,
-        cover: w.cover,
-        url: w.url,
+impl From<bindings::quelle::extension::novel::Metadata> for quelle_types::Metadata {
+    fn from(w: bindings::quelle::extension::novel::Metadata) -> Self {
+        quelle_types::Metadata {
+            name: w.name,
+            value: w.value,
+            ns: w.ns.into(),
+            others: w.others,
+        }
     }
 }
 
-fn search_result_from_wit(
-    w: bindings::quelle::extension::novel::SearchResult,
-) -> quelle_types::SearchResult {
-    quelle_types::SearchResult {
-        novels: w.novels.into_iter().map(basic_novel_from_wit).collect(),
-        total_count: w.total_count,
-        current_page: w.current_page,
-        total_pages: w.total_pages,
-        has_next_page: w.has_next_page,
-        has_previous_page: w.has_previous_page,
+impl From<bindings::quelle::extension::novel::Volume> for quelle_types::Volume {
+    fn from(w: bindings::quelle::extension::novel::Volume) -> Self {
+        quelle_types::Volume {
+            name: w.name,
+            index: w.index,
+            chapters: w.chapters.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<bindings::quelle::extension::novel::Novel> for quelle_types::Novel {
+    fn from(w: bindings::quelle::extension::novel::Novel) -> Self {
+        quelle_types::Novel {
+            url: w.url,
+            authors: w.authors,
+            title: w.title,
+            cover: w.cover,
+            description: w.description,
+            volumes: w.volumes.into_iter().map(Into::into).collect(),
+            metadata: w.metadata.into_iter().map(Into::into).collect(),
+            status: w.status.into(),
+            langs: w.langs,
+        }
+    }
+}
+
+impl From<bindings::quelle::extension::novel::ChapterContent> for quelle_types::ChapterContent {
+    fn from(w: bindings::quelle::extension::novel::ChapterContent) -> Self {
+        quelle_types::ChapterContent { data: w.data }
+    }
+}
+
+impl From<bindings::quelle::extension::novel::BasicNovel> for quelle_types::BasicNovel {
+    fn from(w: bindings::quelle::extension::novel::BasicNovel) -> Self {
+        quelle_types::BasicNovel {
+            title: w.title,
+            cover: w.cover,
+            url: w.url,
+        }
+    }
+}
+
+impl From<bindings::quelle::extension::novel::SearchResult> for quelle_types::SearchResult {
+    fn from(w: bindings::quelle::extension::novel::SearchResult) -> Self {
+        quelle_types::SearchResult {
+            novels: w.novels.into_iter().map(Into::into).collect(),
+            total_count: w.total_count,
+            current_page: w.current_page,
+            total_pages: w.total_pages,
+            has_next_page: w.has_next_page,
+            has_previous_page: w.has_previous_page,
+        }
     }
 }

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod bindings;
 pub mod error;
+pub mod executor;
 pub mod http;
 pub mod scraper;
 mod state;
@@ -14,10 +15,12 @@ use std::sync::Arc;
 use wasmtime::component::*;
 use wasmtime::{Config, Engine, Store};
 
-use crate::bindings::quelle::extension::{error as wit_error, novel, source};
-use crate::bindings::{ComplexSearchQuery, Extension, SearchResult, SimpleSearchQuery};
+use crate::bindings::quelle::extension::{error as wit_error, source};
+use crate::bindings::{ComplexSearchQuery, Extension, SimpleSearchQuery};
 use crate::http::HttpExecutor;
 use crate::state::State;
+
+pub use executor::{Executor, create_engine};
 
 pub struct ExtensionEngine {
     engine: Engine,
@@ -150,31 +153,126 @@ impl<'a> ExtensionRunner<'a> {
     pub async fn fetch_novel_info(
         mut self,
         url: &str,
-    ) -> error::Result<(Self, Result<novel::Novel, wit_error::Error>)> {
-        wrap_extension_method!(self, call_fetch_novel_info, url)
+    ) -> error::Result<(Self, Result<quelle_types::Novel, wit_error::Error>)> {
+        let (runner, result) = wrap_extension_method!(self, call_fetch_novel_info, url)?;
+        Ok((runner, result.map(novel_from_wit)))
     }
 
     /// Safe wrapper around [`Extension::fetch_chapter`].
     pub async fn fetch_chapter(
         mut self,
         url: &str,
-    ) -> error::Result<(Self, Result<novel::ChapterContent, wit_error::Error>)> {
-        wrap_extension_method!(self, call_fetch_chapter, url)
+    ) -> error::Result<(Self, Result<quelle_types::ChapterContent, wit_error::Error>)> {
+        let (runner, result) = wrap_extension_method!(self, call_fetch_chapter, url)?;
+        Ok((runner, result.map(chapter_content_from_wit)))
     }
 
     /// Safe wrapper around [`Extension::simple_search`].
     pub async fn simple_search(
         mut self,
         query: &SimpleSearchQuery,
-    ) -> error::Result<(Self, Result<SearchResult, wit_error::Error>)> {
-        wrap_extension_method!(self, call_simple_search, query)
+    ) -> error::Result<(Self, Result<quelle_types::SearchResult, wit_error::Error>)> {
+        let (runner, result) = wrap_extension_method!(self, call_simple_search, query)?;
+        Ok((runner, result.map(search_result_from_wit)))
     }
 
     /// Safe wrapper around [`Extension::complex_search`].
     pub async fn complex_search(
         mut self,
         query: &ComplexSearchQuery,
-    ) -> error::Result<(Self, Result<SearchResult, wit_error::Error>)> {
-        wrap_extension_method!(self, call_complex_search, query)
+    ) -> error::Result<(Self, Result<quelle_types::SearchResult, wit_error::Error>)> {
+        let (runner, result) = wrap_extension_method!(self, call_complex_search, query)?;
+        Ok((runner, result.map(search_result_from_wit)))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Private WIT → quelle_types conversion functions
+// ---------------------------------------------------------------------------
+
+fn novel_from_wit(w: bindings::quelle::extension::novel::Novel) -> quelle_types::Novel {
+    quelle_types::Novel {
+        url: w.url,
+        authors: w.authors,
+        title: w.title,
+        cover: w.cover,
+        description: w.description,
+        volumes: w.volumes.into_iter().map(volume_from_wit).collect(),
+        metadata: w.metadata.into_iter().map(metadata_from_wit).collect(),
+        status: novel_status_from_wit(w.status),
+        langs: w.langs,
+    }
+}
+
+fn volume_from_wit(w: bindings::quelle::extension::novel::Volume) -> quelle_types::Volume {
+    quelle_types::Volume {
+        name: w.name,
+        index: w.index,
+        chapters: w.chapters.into_iter().map(chapter_from_wit).collect(),
+    }
+}
+
+fn chapter_from_wit(w: bindings::quelle::extension::novel::Chapter) -> quelle_types::Chapter {
+    quelle_types::Chapter {
+        title: w.title,
+        index: w.index,
+        url: w.url,
+        updated_at: w.updated_at,
+    }
+}
+
+fn metadata_from_wit(w: bindings::quelle::extension::novel::Metadata) -> quelle_types::Metadata {
+    use bindings::quelle::extension::novel::Namespace as WitNs;
+    quelle_types::Metadata {
+        name: w.name,
+        value: w.value,
+        ns: match w.ns {
+            WitNs::Dc => quelle_types::Namespace::Dc,
+            WitNs::Opf => quelle_types::Namespace::Opf,
+        },
+        others: w.others,
+    }
+}
+
+fn novel_status_from_wit(
+    w: bindings::quelle::extension::novel::NovelStatus,
+) -> quelle_types::NovelStatus {
+    use bindings::quelle::extension::novel::NovelStatus as WitStatus;
+    match w {
+        WitStatus::Ongoing => quelle_types::NovelStatus::Ongoing,
+        WitStatus::Hiatus => quelle_types::NovelStatus::Hiatus,
+        WitStatus::Completed => quelle_types::NovelStatus::Completed,
+        WitStatus::Stub => quelle_types::NovelStatus::Stub,
+        WitStatus::Dropped => quelle_types::NovelStatus::Dropped,
+        WitStatus::Unknown => quelle_types::NovelStatus::Unknown,
+    }
+}
+
+fn chapter_content_from_wit(
+    w: bindings::quelle::extension::novel::ChapterContent,
+) -> quelle_types::ChapterContent {
+    quelle_types::ChapterContent { data: w.data }
+}
+
+fn basic_novel_from_wit(
+    w: bindings::quelle::extension::novel::BasicNovel,
+) -> quelle_types::BasicNovel {
+    quelle_types::BasicNovel {
+        title: w.title,
+        cover: w.cover,
+        url: w.url,
+    }
+}
+
+fn search_result_from_wit(
+    w: bindings::quelle::extension::novel::SearchResult,
+) -> quelle_types::SearchResult {
+    quelle_types::SearchResult {
+        novels: w.novels.into_iter().map(basic_novel_from_wit).collect(),
+        total_count: w.total_count,
+        current_page: w.current_page,
+        total_pages: w.total_pages,
+        has_next_page: w.has_next_page,
+        has_previous_page: w.has_previous_page,
     }
 }

--- a/crates/export/Cargo.toml
+++ b/crates/export/Cargo.toml
@@ -11,6 +11,7 @@ pdf = ["dep:typst", "dep:typst-pdf", "dep:typst-assets", "dep:comemo", "dep:scra
 [dependencies]
 # Core dependencies
 quelle_storage = { path = "../storage" }
+quelle_types = { path = "../types" }
 async-trait = "0.1"
 tokio = { version = "1.0", features = ["fs", "io-util", "process"] }
 thiserror = "2.0"

--- a/crates/export/src/formats/epub.rs
+++ b/crates/export/src/formats/epub.rs
@@ -9,7 +9,8 @@ use crate::error::{ExportError, Result};
 use crate::traits::Exporter;
 use crate::types::{ExportOptions, ExportResult, FormatInfo};
 
-use quelle_storage::{BookStorage, ChapterContent, Novel, NovelId, WitNovelStatus};
+use quelle_storage::{BookStorage, ChapterContent, Novel, NovelId};
+use quelle_types::NovelStatus;
 
 /// EPUB format exporter.
 pub struct EpubExporter;
@@ -193,7 +194,7 @@ fn build_title_page(novel: &Novel) -> String {
     // Add publication info
     html.push_str("\n    <h2>Publication Info</h2>\n");
 
-    let status = format_novel_status(novel.status);
+    let status = format_novel_status(&novel.status);
     html.push_str(&format!("    <p>Status: {}</p>\n", status));
 
     let total_chapters: usize = novel.volumes.iter().map(|v| v.chapters.len()).sum();
@@ -361,14 +362,14 @@ fn extract_rating(novel: &Novel) -> Option<String> {
 }
 
 /// Format novel status for display.
-fn format_novel_status(status: WitNovelStatus) -> &'static str {
+fn format_novel_status(status: &NovelStatus) -> &'static str {
     match status {
-        WitNovelStatus::Ongoing => "Ongoing",
-        WitNovelStatus::Completed => "Completed",
-        WitNovelStatus::Hiatus => "On Hiatus",
-        WitNovelStatus::Dropped => "Dropped",
-        WitNovelStatus::Stub => "Stub",
-        WitNovelStatus::Unknown => "Unknown",
+        NovelStatus::Ongoing => "Ongoing",
+        NovelStatus::Completed => "Completed",
+        NovelStatus::Hiatus => "On Hiatus",
+        NovelStatus::Dropped => "Dropped",
+        NovelStatus::Stub => "Stub",
+        NovelStatus::Unknown => "Unknown",
     }
 }
 
@@ -395,8 +396,7 @@ fn sanitize_html(html: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quelle_engine::bindings::quelle::extension::novel::{Chapter, Volume};
-    use quelle_storage::{ChapterContent, Novel, WitNovelStatus};
+    use quelle_types::{Chapter, ChapterContent, Metadata, Namespace, Novel, NovelStatus, Volume};
 
     fn create_test_novel() -> Novel {
         Novel {
@@ -409,30 +409,30 @@ mod tests {
             ],
             cover: None,
             langs: vec!["en".to_string()],
-            status: WitNovelStatus::Ongoing,
+            status: NovelStatus::Ongoing,
             metadata: vec![
-                quelle_engine::bindings::quelle::extension::novel::Metadata {
+                Metadata {
                     name: "subject".to_string(),
                     value: "Fantasy".to_string(),
-                    ns: quelle_engine::bindings::quelle::extension::novel::Namespace::Dc,
+                    ns: Namespace::Dc,
                     others: vec![],
                 },
-                quelle_engine::bindings::quelle::extension::novel::Metadata {
+                Metadata {
                     name: "subject".to_string(),
                     value: "Adventure".to_string(),
-                    ns: quelle_engine::bindings::quelle::extension::novel::Namespace::Dc,
+                    ns: Namespace::Dc,
                     others: vec![],
                 },
-                quelle_engine::bindings::quelle::extension::novel::Metadata {
+                Metadata {
                     name: "tag".to_string(),
                     value: "Magic System".to_string(),
-                    ns: quelle_engine::bindings::quelle::extension::novel::Namespace::Opf,
+                    ns: Namespace::Opf,
                     others: vec![],
                 },
-                quelle_engine::bindings::quelle::extension::novel::Metadata {
+                Metadata {
                     name: "rating".to_string(),
                     value: "4.5 (123 ratings)".to_string(),
-                    ns: quelle_engine::bindings::quelle::extension::novel::Namespace::Opf,
+                    ns: Namespace::Opf,
                     others: vec![],
                 },
             ],
@@ -547,7 +547,7 @@ mod tests {
             description: vec![],
             cover: None,
             langs: vec![],
-            status: WitNovelStatus::Unknown,
+            status: NovelStatus::Unknown,
             metadata: vec![],
             volumes: vec![],
         };
@@ -569,7 +569,7 @@ mod tests {
             description: vec![],
             cover: None,
             langs: vec![],
-            status: WitNovelStatus::Unknown,
+            status: NovelStatus::Unknown,
             metadata: vec![],
             volumes: vec![],
         };
@@ -579,11 +579,11 @@ mod tests {
 
     #[test]
     fn test_format_novel_status() {
-        assert_eq!(format_novel_status(WitNovelStatus::Ongoing), "Ongoing");
-        assert_eq!(format_novel_status(WitNovelStatus::Completed), "Completed");
-        assert_eq!(format_novel_status(WitNovelStatus::Hiatus), "On Hiatus");
-        assert_eq!(format_novel_status(WitNovelStatus::Dropped), "Dropped");
-        assert_eq!(format_novel_status(WitNovelStatus::Stub), "Stub");
-        assert_eq!(format_novel_status(WitNovelStatus::Unknown), "Unknown");
+        assert_eq!(format_novel_status(&NovelStatus::Ongoing), "Ongoing");
+        assert_eq!(format_novel_status(&NovelStatus::Completed), "Completed");
+        assert_eq!(format_novel_status(&NovelStatus::Hiatus), "On Hiatus");
+        assert_eq!(format_novel_status(&NovelStatus::Dropped), "Dropped");
+        assert_eq!(format_novel_status(&NovelStatus::Stub), "Stub");
+        assert_eq!(format_novel_status(&NovelStatus::Unknown), "Unknown");
     }
 }

--- a/crates/extension/src/register.rs
+++ b/crates/extension/src/register.rs
@@ -1,6 +1,8 @@
+use std::sync::OnceLock;
+
 use crate::QuelleExtension;
 
-static mut EXTENSION: Option<Box<dyn QuelleExtension>> = None;
+static EXTENSION: OnceLock<Box<dyn QuelleExtension>> = OnceLock::new();
 
 /// Registers the provided type as a Quelle extension.
 ///
@@ -21,7 +23,7 @@ macro_rules! register_extension {
 
 #[doc(hidden)]
 pub fn register_extension_internal(build_extension: fn() -> Box<dyn QuelleExtension>) {
-    unsafe { EXTENSION = Some((build_extension)()) }
+    let _ = EXTENSION.set((build_extension)());
 }
 
 pub fn register_tracing() {
@@ -30,9 +32,6 @@ pub fn register_tracing() {
     tracing_subscriber::registry().with(HostLayer).init();
 }
 
-pub fn extension() -> &'static mut dyn QuelleExtension {
-    #[expect(static_mut_refs)]
-    unsafe {
-        EXTENSION.as_deref_mut().unwrap()
-    }
+pub fn extension() -> &'static dyn QuelleExtension {
+    EXTENSION.get().unwrap().as_ref()
 }

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -17,5 +17,5 @@ url = "2.5"
 uuid = { version = "1.0", features = ["v4"] }
 tracing.workspace = true
 
-# Import WIT types from engine crate
-quelle_engine = { path = "../engine" }
+# Import domain types from types crate (no Wasmtime dependency)
+quelle_types = { path = "../types" }

--- a/crates/storage/src/backends/filesystem.rs
+++ b/crates/storage/src/backends/filesystem.rs
@@ -5,16 +5,16 @@ use chrono::{DateTime, Utc};
 
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 use tokio::fs;
 
 use crate::error::{BookStorageError, Result};
 use crate::models::{
-    chapter_content_from_json, chapter_content_to_json, novel_from_json, novel_to_json,
-    ContentIndex,
+    chapter_content_from_json, chapter_content_to_json, ContentIndex,
 };
 use crate::traits::BookStorage;
 use crate::types::{
-    Asset, AssetId, AssetSummary, ChapterInfo, CleanupReport, NovelFilter, NovelId, NovelSummary,
+    Asset, AssetId, ChapterInfo, CleanupReport, NovelFilter, NovelId, NovelSummary,
 };
 use crate::{ChapterContent, Novel};
 
@@ -40,6 +40,7 @@ use crate::{ChapterContent, Novel};
 #[derive(Debug, Clone)]
 pub struct FilesystemStorage {
     root_path: PathBuf,
+    index_lock: Arc<tokio::sync::Mutex<()>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -95,6 +96,7 @@ impl FilesystemStorage {
     pub fn new<P: AsRef<Path>>(root_path: P) -> Self {
         Self {
             root_path: root_path.as_ref().to_path_buf(),
+            index_lock: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 
@@ -118,6 +120,7 @@ impl FilesystemStorage {
         // Initialize index if it doesn't exist
         let index_path = self.get_index_path();
         if !index_path.exists() {
+            let _guard = self.index_lock.lock().await;
             self.save_index(&StorageIndex::default()).await?;
         }
 
@@ -385,6 +388,7 @@ impl FilesystemStorage {
     }
 
     async fn update_index_for_novel(&self, novel_id: &NovelId, novel: &Novel) -> Result<()> {
+        let _guard = self.index_lock.lock().await;
         let mut index = self.load_index().await?;
         let now = Utc::now();
 
@@ -413,6 +417,7 @@ impl FilesystemStorage {
     }
 
     async fn remove_from_index(&self, novel_id: &NovelId) -> Result<()> {
+        let _guard = self.index_lock.lock().await;
         let mut index = self.load_index().await?;
         index.novels.retain(|n| n.id != *novel_id);
         index.last_updated = Utc::now();
@@ -469,6 +474,7 @@ impl FilesystemStorage {
     }
 
     async fn update_index_stored_chapters(&self, novel_id: &NovelId) -> Result<()> {
+        let _guard = self.index_lock.lock().await;
         let mut index = self.load_index().await?;
 
         // Find the novel in the index and update its stored chapter count
@@ -481,6 +487,7 @@ impl FilesystemStorage {
     }
 
     async fn add_asset_to_index(&self, asset: &Asset, data_size: u64) -> Result<()> {
+        let _guard = self.index_lock.lock().await;
         let mut index = self.load_index().await?;
 
         let indexed_asset = IndexedAsset {
@@ -502,6 +509,7 @@ impl FilesystemStorage {
     }
 
     async fn remove_asset_from_index(&self, asset_id: &AssetId) -> Result<()> {
+        let _guard = self.index_lock.lock().await;
         let mut index = self.load_index().await?;
         index.assets.retain(|a| a.id != *asset_id);
         self.save_index(&index).await?;
@@ -994,6 +1002,22 @@ impl BookStorage for FilesystemStorage {
         Ok(None)
     }
 
+    async fn find_novel_id_by_url(&self, url: &str) -> Result<Option<NovelId>> {
+        let normalized_url = self.normalize_url(url);
+        let index = self.load_index().await?;
+
+        for indexed_novel in &index.novels {
+            let parts: Vec<&str> = indexed_novel.id.as_str().splitn(2, "::").collect();
+            if let Some(novel_url) = parts.get(1) {
+                if *novel_url == normalized_url {
+                    return Ok(Some(indexed_novel.id.clone()));
+                }
+            }
+        }
+
+        Ok(None)
+    }
+
     async fn list_chapters(&self, novel_id: &NovelId) -> Result<Vec<ChapterInfo>> {
         // Read the novel structure and metadata
         let (novel, metadata) = self.read_novel_file_combined(novel_id).await?;
@@ -1245,14 +1269,14 @@ impl BookStorage for FilesystemStorage {
         Ok(None)
     }
 
-    async fn get_novel_assets(&self, novel_id: &NovelId) -> Result<Vec<AssetSummary>> {
+    async fn get_novel_assets(&self, novel_id: &NovelId) -> Result<Vec<Asset>> {
         let index = self.load_index().await?;
 
         let summaries = index
             .assets
             .iter()
             .filter(|asset| asset.novel_id == *novel_id)
-            .map(|indexed_asset| AssetSummary {
+            .map(|indexed_asset| Asset {
                 id: indexed_asset.id.clone(),
                 novel_id: indexed_asset.novel_id.clone(),
                 original_url: indexed_asset.original_url.clone(),
@@ -1290,40 +1314,24 @@ impl FilesystemStorage {
                     source: Some(eyre::eyre!("Failed to read novel file: {}", e)),
                 })?;
 
-        // Parse the combined JSON
-        let combined: serde_json::Value =
+        #[derive(serde::Deserialize)]
+        struct CombinedNovelFile {
+            novel: quelle_types::Novel,
+            metadata: NovelStorageMetadata,
+        }
+
+        let mut combined: CombinedNovelFile =
             serde_json::from_str(&content).map_err(|e| BookStorageError::DataConversionError {
                 message: "Failed to parse novel file".to_string(),
                 source: Some(eyre::eyre!("JSON error: {}", e)),
             })?;
 
-        // Extract and convert the novel part
-        let novel_value = combined["novel"].clone();
-        let novel_json = serde_json::to_string(&novel_value).map_err(|e| {
-            BookStorageError::DataConversionError {
-                message: "Failed to extract novel data".to_string(),
-                source: Some(eyre::eyre!("JSON error: {}", e)),
-            }
-        })?;
-        let novel = novel_from_json(&novel_json)?;
-
-        // Extract and convert the metadata part
-        let metadata_value = combined["metadata"].clone();
-        let mut metadata: NovelStorageMetadata =
-            serde_json::from_value(metadata_value).map_err(|e| {
-                BookStorageError::DataConversionError {
-                    message: "Failed to extract metadata".to_string(),
-                    source: Some(eyre::eyre!("JSON error: {}", e)),
-                }
-            })?;
-
         // Handle missing content_index field for backwards compatibility
-        if metadata.content_index.chapters.is_empty() {
-            // Initialize empty content index for existing novels
-            metadata.content_index = ContentIndex::default();
+        if combined.metadata.content_index.chapters.is_empty() {
+            combined.metadata.content_index = ContentIndex::default();
         }
 
-        Ok((novel, metadata))
+        Ok((combined.novel, combined.metadata))
     }
 
     /// Write the combined novel file structure (novel + metadata) atomically
@@ -1344,16 +1352,13 @@ impl FilesystemStorage {
                 })?;
         }
 
-        // Convert novel to JSON
-        let novel_json = novel_to_json(novel)?;
-        let novel_value = serde_json::from_str::<serde_json::Value>(&novel_json).map_err(|e| {
-            BookStorageError::DataConversionError {
-                message: "Failed to parse novel JSON".to_string(),
+        // Serialize novel and metadata directly into the combined structure
+        let novel_value =
+            serde_json::to_value(novel).map_err(|e| BookStorageError::DataConversionError {
+                message: "Failed to serialize novel".to_string(),
                 source: Some(eyre::eyre!("JSON error: {}", e)),
-            }
-        })?;
+            })?;
 
-        // Convert metadata to JSON value
         let metadata_value =
             serde_json::to_value(metadata).map_err(|e| BookStorageError::DataConversionError {
                 message: "Failed to serialize metadata".to_string(),

--- a/crates/storage/src/backends/filesystem.rs
+++ b/crates/storage/src/backends/filesystem.rs
@@ -69,7 +69,7 @@ struct IndexedNovel {
     id: NovelId,
     title: String,
     authors: Vec<String>,
-    status: crate::types::NovelStatus,
+    status: quelle_types::NovelStatus,
     total_chapters: u32,
     stored_chapters: u32,
     created_at: DateTime<Utc>,
@@ -399,7 +399,7 @@ impl FilesystemStorage {
             id: novel_id.clone(),
             title: novel.title.clone(),
             authors: novel.authors.clone(),
-            status: novel.status.into(),
+            status: novel.status.clone(),
             total_chapters: self.count_total_chapters(novel),
             stored_chapters,
             created_at: now,
@@ -518,11 +518,9 @@ impl FilesystemStorage {
 
     /// Normalize all URLs in a novel (including chapter URLs)
     fn normalize_novel_urls(&self, novel: &Novel) -> Novel {
-        use quelle_engine::bindings::quelle::extension::novel::{
-            Chapter, Novel as WitNovel, Volume,
-        };
+        use quelle_types::{Chapter, Novel, Volume};
 
-        WitNovel {
+        Novel {
             url: self.normalize_url(&novel.url),
             authors: novel.authors.clone(),
             title: novel.title.clone(),
@@ -547,7 +545,7 @@ impl FilesystemStorage {
                 })
                 .collect(),
             metadata: novel.metadata.clone(),
-            status: novel.status,
+            status: novel.status.clone(),
             langs: novel.langs.clone(),
         }
     }
@@ -1461,9 +1459,7 @@ impl FilesystemStorage {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use quelle_engine::bindings::quelle::extension::novel::{
-        Chapter, ChapterContent, Novel, NovelStatus, Volume,
-    };
+    use quelle_types::{Chapter, ChapterContent, Novel, NovelStatus, Volume};
     use tempfile::TempDir;
 
     fn create_test_novel() -> Novel {
@@ -2263,9 +2259,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_end_to_end_asset_workflow() {
-        use quelle_engine::bindings::quelle::extension::novel::{
-            Chapter, Novel, NovelStatus, Volume,
-        };
+        use quelle_types::{Chapter, Novel, NovelStatus, Volume};
         use std::io::Cursor;
 
         let temp_dir = tempfile::tempdir().unwrap();

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -14,7 +14,7 @@ pub use backends::FilesystemStorage;
 pub use error::{BookStorageError, Result};
 pub use traits::BookStorage;
 pub use types::{
-    Asset, AssetId, AssetSummary, ChapterContentStatus, ChapterInfo, CleanupReport, NovelFilter,
+    Asset, AssetId, ChapterContentStatus, ChapterInfo, CleanupReport, NovelFilter,
     NovelId, NovelSummary,
 };
 

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -18,34 +18,5 @@ pub use types::{
     NovelId, NovelSummary,
 };
 
-// Import the WIT types that we'll be working with
-pub use quelle_engine::bindings::quelle::extension::novel::{
-    ChapterContent, Novel, NovelStatus as WitNovelStatus,
-};
-
-// Convert between our types and WIT types
-impl From<WitNovelStatus> for types::NovelStatus {
-    fn from(status: WitNovelStatus) -> Self {
-        match status {
-            WitNovelStatus::Ongoing => Self::Ongoing,
-            WitNovelStatus::Hiatus => Self::Hiatus,
-            WitNovelStatus::Completed => Self::Completed,
-            WitNovelStatus::Stub => Self::Stub,
-            WitNovelStatus::Dropped => Self::Dropped,
-            WitNovelStatus::Unknown => Self::Unknown,
-        }
-    }
-}
-
-impl From<types::NovelStatus> for WitNovelStatus {
-    fn from(status: types::NovelStatus) -> Self {
-        match status {
-            types::NovelStatus::Ongoing => Self::Ongoing,
-            types::NovelStatus::Hiatus => Self::Hiatus,
-            types::NovelStatus::Completed => Self::Completed,
-            types::NovelStatus::Stub => Self::Stub,
-            types::NovelStatus::Dropped => Self::Dropped,
-            types::NovelStatus::Unknown => Self::Unknown,
-        }
-    }
-}
+// Re-export domain types from quelle_types
+pub use quelle_types::{ChapterContent, Novel, NovelStatus};

--- a/crates/storage/src/models.rs
+++ b/crates/storage/src/models.rs
@@ -1,9 +1,8 @@
 //! Storage model types and conversion utilities.
 //!
 //! Since the domain types now live in `quelle_types`, this module provides
-//! storage-specific models that can be serialized/deserialized and conversion
-//! utilities between the `quelle_types` domain types and the compact storage
-//! representation.
+//! storage-specific models and serialization helpers. The `quelle_types`
+//! structs are serialized directly — no intermediate `Storage*` wrappers needed.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -11,7 +10,6 @@ use std::collections::HashMap;
 
 use crate::error::{BookStorageError, Result};
 use crate::{ChapterContent, Novel};
-use quelle_types::{Chapter, Metadata, Namespace, NovelStatus, Volume};
 
 /// Content metadata for a single chapter
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -51,241 +49,36 @@ impl ContentIndex {
     }
 }
 
-/// Storage representation of a Novel
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StorageNovel {
-    pub url: String,
-    pub authors: Vec<String>,
-    pub title: String,
-    pub cover: Option<String>,
-    pub description: Vec<String>,
-    pub volumes: Vec<StorageVolume>,
-    pub metadata: Vec<StorageMetadata>,
-    pub status: String, // We'll store as string to avoid enum conversion issues
-    pub langs: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StorageVolume {
-    pub name: String,
-    pub index: i32,
-    pub chapters: Vec<StorageChapter>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StorageChapter {
-    pub title: String,
-    pub index: i32,
-    pub url: String,
-    pub updated_at: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StorageMetadata {
-    pub name: String,
-    pub value: String,
-    pub ns: String, // Store as string to avoid enum conversion
-    pub others: Vec<(String, String)>,
-}
-
-/// Storage representation of ChapterContent
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct StorageChapterContent {
-    pub data: String,
-}
-
-impl StorageNovel {
-    /// Convert from a `quelle_types::Novel` to the storage representation.
-    pub fn from_novel(novel: &Novel) -> Self {
-        Self {
-            url: novel.url.clone(),
-            authors: novel.authors.clone(),
-            title: novel.title.clone(),
-            cover: novel.cover.clone(),
-            description: novel.description.clone(),
-            volumes: novel
-                .volumes
-                .iter()
-                .map(StorageVolume::from_volume)
-                .collect(),
-            metadata: novel
-                .metadata
-                .iter()
-                .map(StorageMetadata::from_metadata)
-                .collect(),
-            status: match novel.status {
-                NovelStatus::Ongoing => "Ongoing".to_string(),
-                NovelStatus::Hiatus => "Hiatus".to_string(),
-                NovelStatus::Completed => "Completed".to_string(),
-                NovelStatus::Stub => "Stub".to_string(),
-                NovelStatus::Dropped => "Dropped".to_string(),
-                NovelStatus::Unknown => "Unknown".to_string(),
-            },
-            langs: novel.langs.clone(),
-        }
-    }
-
-    /// Convert from the storage representation back to a `quelle_types::Novel`.
-    pub fn to_novel(&self) -> Result<Novel> {
-        let status = match self.status.as_str() {
-            "Ongoing" => NovelStatus::Ongoing,
-            "Hiatus" => NovelStatus::Hiatus,
-            "Completed" => NovelStatus::Completed,
-            "Stub" => NovelStatus::Stub,
-            "Dropped" => NovelStatus::Dropped,
-            _ => NovelStatus::Unknown,
-        };
-
-        let volumes: Result<Vec<Volume>> = self.volumes.iter().map(|v| v.to_volume()).collect();
-
-        let metadata: Result<Vec<Metadata>> =
-            self.metadata.iter().map(|m| m.to_metadata()).collect();
-
-        Ok(Novel {
-            url: self.url.clone(),
-            authors: self.authors.clone(),
-            title: self.title.clone(),
-            cover: self.cover.clone(),
-            description: self.description.clone(),
-            volumes: volumes?,
-            metadata: metadata?,
-            status,
-            langs: self.langs.clone(),
-        })
-    }
-}
-
-impl StorageVolume {
-    fn from_volume(volume: &Volume) -> Self {
-        Self {
-            name: volume.name.clone(),
-            index: volume.index,
-            chapters: volume
-                .chapters
-                .iter()
-                .map(StorageChapter::from_chapter)
-                .collect(),
-        }
-    }
-
-    fn to_volume(&self) -> Result<Volume> {
-        let chapters: Result<Vec<_>> = self.chapters.iter().map(|c| c.to_chapter()).collect();
-
-        Ok(Volume {
-            name: self.name.clone(),
-            index: self.index,
-            chapters: chapters?,
-        })
-    }
-}
-
-impl StorageChapter {
-    fn from_chapter(chapter: &Chapter) -> Self {
-        Self {
-            title: chapter.title.clone(),
-            index: chapter.index,
-            url: chapter.url.clone(),
-            updated_at: chapter.updated_at.clone(),
-        }
-    }
-
-    fn to_chapter(&self) -> Result<Chapter> {
-        Ok(Chapter {
-            title: self.title.clone(),
-            index: self.index,
-            url: self.url.clone(),
-            updated_at: self.updated_at.clone(),
-        })
-    }
-}
-
-impl StorageMetadata {
-    fn from_metadata(metadata: &Metadata) -> Self {
-        Self {
-            name: metadata.name.clone(),
-            value: metadata.value.clone(),
-            ns: match metadata.ns {
-                Namespace::Dc => "Dc".to_string(),
-                Namespace::Opf => "Opf".to_string(),
-            },
-            others: metadata.others.clone(),
-        }
-    }
-
-    fn to_metadata(&self) -> Result<Metadata> {
-        let ns = match self.ns.as_str() {
-            "Dc" => Namespace::Dc,
-            "Opf" => Namespace::Opf,
-            _ => {
-                return Err(BookStorageError::InvalidNovelData {
-                    message: format!("Invalid namespace: {}", self.ns),
-                    source: None,
-                });
-            }
-        };
-
-        Ok(Metadata {
-            name: self.name.clone(),
-            value: self.value.clone(),
-            ns,
-            others: self.others.clone(),
-        })
-    }
-}
-
-impl StorageChapterContent {
-    /// Convert from a `quelle_types::ChapterContent` to the storage representation.
-    pub fn from_chapter_content(content: &ChapterContent) -> Self {
-        Self {
-            data: content.data.clone(),
-        }
-    }
-
-    /// Convert from the storage representation back to a `quelle_types::ChapterContent`.
-    pub fn to_chapter_content(&self) -> ChapterContent {
-        ChapterContent {
-            data: self.data.clone(),
-        }
-    }
-}
-
-/// Helper functions for easy conversion
+/// Serialize a [`Novel`] to a pretty-printed JSON string.
 pub fn novel_to_json(novel: &Novel) -> Result<String> {
-    let storage_novel = StorageNovel::from_novel(novel);
-    serde_json::to_string_pretty(&storage_novel).map_err(|e| {
-        BookStorageError::DataConversionError {
-            message: "Failed to serialize novel to JSON".to_string(),
-            source: Some(eyre::eyre!("JSON error: {}", e)),
-        }
+    serde_json::to_string_pretty(novel).map_err(|e| BookStorageError::DataConversionError {
+        message: "Failed to serialize novel to JSON".to_string(),
+        source: Some(eyre::eyre!("JSON error: {}", e)),
     })
 }
 
+/// Deserialize a [`Novel`] from a JSON string.
 pub fn novel_from_json(json: &str) -> Result<Novel> {
-    let storage_novel: StorageNovel =
-        serde_json::from_str(json).map_err(|e| BookStorageError::DataConversionError {
-            message: "Failed to deserialize novel from JSON".to_string(),
-            source: Some(eyre::eyre!("JSON error: {}", e)),
-        })?;
-
-    storage_novel.to_novel()
-}
-
-pub fn chapter_content_to_json(content: &ChapterContent) -> Result<String> {
-    let storage_content = StorageChapterContent::from_chapter_content(content);
-    serde_json::to_string_pretty(&storage_content).map_err(|e| {
-        BookStorageError::DataConversionError {
-            message: "Failed to serialize chapter content to JSON".to_string(),
-            source: Some(eyre::eyre!("JSON error: {}", e)),
-        }
+    serde_json::from_str::<Novel>(json).map_err(|e| BookStorageError::DataConversionError {
+        message: "Failed to deserialize novel from JSON".to_string(),
+        source: Some(eyre::eyre!("JSON error: {}", e)),
     })
 }
 
+/// Serialize a [`ChapterContent`] to a pretty-printed JSON string.
+pub fn chapter_content_to_json(content: &ChapterContent) -> Result<String> {
+    serde_json::to_string_pretty(content).map_err(|e| BookStorageError::DataConversionError {
+        message: "Failed to serialize chapter content to JSON".to_string(),
+        source: Some(eyre::eyre!("JSON error: {}", e)),
+    })
+}
+
+/// Deserialize a [`ChapterContent`] from a JSON string.
 pub fn chapter_content_from_json(json: &str) -> Result<ChapterContent> {
-    let storage_content: StorageChapterContent =
-        serde_json::from_str(json).map_err(|e| BookStorageError::DataConversionError {
+    serde_json::from_str::<ChapterContent>(json).map_err(|e| {
+        BookStorageError::DataConversionError {
             message: "Failed to deserialize chapter content from JSON".to_string(),
             source: Some(eyre::eyre!("JSON error: {}", e)),
-        })?;
-
-    Ok(storage_content.to_chapter_content())
+        }
+    })
 }

--- a/crates/storage/src/models.rs
+++ b/crates/storage/src/models.rs
@@ -1,7 +1,9 @@
 //! Storage model types and conversion utilities.
 //!
-//! Since WIT-generated types don't implement Serde traits, we define storage-specific
-//! models that can be serialized and provide conversion utilities between WIT and storage types.
+//! Since the domain types now live in `quelle_types`, this module provides
+//! storage-specific models that can be serialized/deserialized and conversion
+//! utilities between the `quelle_types` domain types and the compact storage
+//! representation.
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -9,10 +11,7 @@ use std::collections::HashMap;
 
 use crate::error::{BookStorageError, Result};
 use crate::{ChapterContent, Novel};
-use quelle_engine::bindings::quelle::extension::novel::{
-    Chapter, ChapterContent as WitChapterContent, Metadata, Namespace, Novel as WitNovel,
-    NovelStatus, Volume,
-};
+use quelle_types::{Chapter, Metadata, Namespace, NovelStatus, Volume};
 
 /// Content metadata for a single chapter
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -96,8 +95,8 @@ pub struct StorageChapterContent {
 }
 
 impl StorageNovel {
-    /// Convert from WIT Novel type to storage type
-    pub fn from_wit_novel(novel: &Novel) -> Self {
+    /// Convert from a `quelle_types::Novel` to the storage representation.
+    pub fn from_novel(novel: &Novel) -> Self {
         Self {
             url: novel.url.clone(),
             authors: novel.authors.clone(),
@@ -107,12 +106,12 @@ impl StorageNovel {
             volumes: novel
                 .volumes
                 .iter()
-                .map(StorageVolume::from_wit_volume)
+                .map(StorageVolume::from_volume)
                 .collect(),
             metadata: novel
                 .metadata
                 .iter()
-                .map(StorageMetadata::from_wit_metadata)
+                .map(StorageMetadata::from_metadata)
                 .collect(),
             status: match novel.status {
                 NovelStatus::Ongoing => "Ongoing".to_string(),
@@ -126,9 +125,8 @@ impl StorageNovel {
         }
     }
 
-    /// Convert to WIT Novel type from storage type
-    pub fn to_wit_novel(&self) -> Result<Novel> {
-        // Convert status string back to enum
+    /// Convert from the storage representation back to a `quelle_types::Novel`.
+    pub fn to_novel(&self) -> Result<Novel> {
         let status = match self.status.as_str() {
             "Ongoing" => NovelStatus::Ongoing,
             "Hiatus" => NovelStatus::Hiatus,
@@ -138,12 +136,12 @@ impl StorageNovel {
             _ => NovelStatus::Unknown,
         };
 
-        let volumes: Result<Vec<Volume>> = self.volumes.iter().map(|v| v.to_wit_volume()).collect();
+        let volumes: Result<Vec<Volume>> = self.volumes.iter().map(|v| v.to_volume()).collect();
 
         let metadata: Result<Vec<Metadata>> =
-            self.metadata.iter().map(|m| m.to_wit_metadata()).collect();
+            self.metadata.iter().map(|m| m.to_metadata()).collect();
 
-        Ok(WitNovel {
+        Ok(Novel {
             url: self.url.clone(),
             authors: self.authors.clone(),
             title: self.title.clone(),
@@ -158,20 +156,20 @@ impl StorageNovel {
 }
 
 impl StorageVolume {
-    fn from_wit_volume(volume: &Volume) -> Self {
+    fn from_volume(volume: &Volume) -> Self {
         Self {
             name: volume.name.clone(),
             index: volume.index,
             chapters: volume
                 .chapters
                 .iter()
-                .map(StorageChapter::from_wit_chapter)
+                .map(StorageChapter::from_chapter)
                 .collect(),
         }
     }
 
-    fn to_wit_volume(&self) -> Result<Volume> {
-        let chapters: Result<Vec<_>> = self.chapters.iter().map(|c| c.to_wit_chapter()).collect();
+    fn to_volume(&self) -> Result<Volume> {
+        let chapters: Result<Vec<_>> = self.chapters.iter().map(|c| c.to_chapter()).collect();
 
         Ok(Volume {
             name: self.name.clone(),
@@ -182,7 +180,7 @@ impl StorageVolume {
 }
 
 impl StorageChapter {
-    fn from_wit_chapter(chapter: &Chapter) -> Self {
+    fn from_chapter(chapter: &Chapter) -> Self {
         Self {
             title: chapter.title.clone(),
             index: chapter.index,
@@ -191,7 +189,7 @@ impl StorageChapter {
         }
     }
 
-    fn to_wit_chapter(&self) -> Result<Chapter> {
+    fn to_chapter(&self) -> Result<Chapter> {
         Ok(Chapter {
             title: self.title.clone(),
             index: self.index,
@@ -202,7 +200,7 @@ impl StorageChapter {
 }
 
 impl StorageMetadata {
-    fn from_wit_metadata(metadata: &Metadata) -> Self {
+    fn from_metadata(metadata: &Metadata) -> Self {
         Self {
             name: metadata.name.clone(),
             value: metadata.value.clone(),
@@ -214,8 +212,7 @@ impl StorageMetadata {
         }
     }
 
-    fn to_wit_metadata(&self) -> Result<Metadata> {
-        // Convert namespace string back to enum
+    fn to_metadata(&self) -> Result<Metadata> {
         let ns = match self.ns.as_str() {
             "Dc" => Namespace::Dc,
             "Opf" => Namespace::Opf,
@@ -237,16 +234,16 @@ impl StorageMetadata {
 }
 
 impl StorageChapterContent {
-    /// Convert from WIT ChapterContent type to storage type
-    pub fn from_wit_chapter_content(content: &ChapterContent) -> Self {
+    /// Convert from a `quelle_types::ChapterContent` to the storage representation.
+    pub fn from_chapter_content(content: &ChapterContent) -> Self {
         Self {
             data: content.data.clone(),
         }
     }
 
-    /// Convert to WIT ChapterContent type from storage type
-    pub fn to_wit_chapter_content(&self) -> ChapterContent {
-        WitChapterContent {
+    /// Convert from the storage representation back to a `quelle_types::ChapterContent`.
+    pub fn to_chapter_content(&self) -> ChapterContent {
+        ChapterContent {
             data: self.data.clone(),
         }
     }
@@ -254,7 +251,7 @@ impl StorageChapterContent {
 
 /// Helper functions for easy conversion
 pub fn novel_to_json(novel: &Novel) -> Result<String> {
-    let storage_novel = StorageNovel::from_wit_novel(novel);
+    let storage_novel = StorageNovel::from_novel(novel);
     serde_json::to_string_pretty(&storage_novel).map_err(|e| {
         BookStorageError::DataConversionError {
             message: "Failed to serialize novel to JSON".to_string(),
@@ -270,11 +267,11 @@ pub fn novel_from_json(json: &str) -> Result<Novel> {
             source: Some(eyre::eyre!("JSON error: {}", e)),
         })?;
 
-    storage_novel.to_wit_novel()
+    storage_novel.to_novel()
 }
 
 pub fn chapter_content_to_json(content: &ChapterContent) -> Result<String> {
-    let storage_content = StorageChapterContent::from_wit_chapter_content(content);
+    let storage_content = StorageChapterContent::from_chapter_content(content);
     serde_json::to_string_pretty(&storage_content).map_err(|e| {
         BookStorageError::DataConversionError {
             message: "Failed to serialize chapter content to JSON".to_string(),
@@ -290,5 +287,5 @@ pub fn chapter_content_from_json(json: &str) -> Result<ChapterContent> {
             source: Some(eyre::eyre!("JSON error: {}", e)),
         })?;
 
-    Ok(storage_content.to_wit_chapter_content())
+    Ok(storage_content.to_chapter_content())
 }

--- a/crates/storage/src/traits.rs
+++ b/crates/storage/src/traits.rs
@@ -5,7 +5,7 @@ use tokio::io::AsyncRead;
 
 use crate::error::Result;
 use crate::types::{
-    Asset, AssetId, AssetSummary, ChapterInfo, CleanupReport, NovelFilter, NovelId, NovelSummary,
+    Asset, AssetId, ChapterInfo, CleanupReport, NovelFilter, NovelId, NovelSummary,
 };
 
 use crate::{ChapterContent, Novel};
@@ -101,6 +101,12 @@ pub trait BookStorage: Send + Sync {
     /// This is the most common lookup pattern since users typically know the novel URL.
     async fn find_novel_by_url(&self, url: &str) -> Result<Option<Novel>>;
 
+    /// Find the NovelId for a novel by its URL.
+    ///
+    /// This is more efficient than `find_novel_by_url` when you only need the ID,
+    /// as it avoids reading the full novel file from disk.
+    async fn find_novel_id_by_url(&self, url: &str) -> Result<Option<NovelId>>;
+
     /// List chapters for a novel.
     ///
     /// Returns information about all chapters for the novel,
@@ -142,5 +148,5 @@ pub trait BookStorage: Send + Sync {
     async fn find_asset_by_url(&self, url: &str) -> Result<Option<AssetId>>;
 
     /// Get all assets for a novel.
-    async fn get_novel_assets(&self, novel_id: &NovelId) -> Result<Vec<AssetSummary>>;
+    async fn get_novel_assets(&self, novel_id: &NovelId) -> Result<Vec<Asset>>;
 }

--- a/crates/storage/src/types.rs
+++ b/crates/storage/src/types.rs
@@ -46,20 +46,9 @@ pub struct NovelSummary {
     pub id: NovelId,
     pub title: String,
     pub authors: Vec<String>,
-    pub status: NovelStatus,
+    pub status: quelle_types::NovelStatus,
     pub total_chapters: u32,
     pub stored_chapters: u32,
-}
-
-/// Status of a novel (from WIT definitions).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum NovelStatus {
-    Ongoing,
-    Hiatus,
-    Completed,
-    Stub,
-    Dropped,
-    Unknown,
 }
 
 /// Filter criteria for querying novels.

--- a/crates/storage/src/types.rs
+++ b/crates/storage/src/types.rs
@@ -264,14 +264,3 @@ pub struct Asset {
     pub size: u64,
     pub filename: String,
 }
-
-/// Summary information about an asset (without binary data)
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct AssetSummary {
-    pub id: AssetId,
-    pub novel_id: NovelId,
-    pub original_url: String,
-    pub mime_type: String,
-    pub size: u64,
-    pub filename: String,
-}

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 quelle_engine = { path = "../engine" }
+quelle_types = { path = "../types" }
 serde = { workspace = true, features = ["derive"] }
 serde_json = "1.0.143"
 tokio = { version = "1.0", features = ["full"] }

--- a/crates/store/src/manager/core.rs
+++ b/crates/store/src/manager/core.rs
@@ -556,7 +556,7 @@ impl StoreManager {
     }
 
     /// Internal helper: find and, if necessary, install an extension for the given URL.
-    async fn find_and_install_for_url(
+    pub async fn find_and_install_for_url(
         &mut self,
         url: &str,
     ) -> crate::error::Result<crate::models::InstalledExtension> {
@@ -569,70 +569,6 @@ impl StoreManager {
         }
 
         self.install(&extension_id, None, None).await
-    }
-
-    /// Find, install if needed, and use the appropriate extension to fetch novel metadata.
-    ///
-    /// Returns an error if no extension handles the URL or if the extension call fails.
-    pub async fn fetch_novel(
-        &mut self,
-        engine: &quelle_engine::ExtensionEngine,
-        url: &str,
-    ) -> crate::error::Result<quelle_types::Novel> {
-        let installed = self.find_and_install_for_url(url).await?;
-        let wasm_bytes = self
-            .registry
-            .get_extension_wasm_bytes(&installed.id)
-            .await?;
-        let runner = engine
-            .new_runner_from_bytes(&wasm_bytes)
-            .await
-            .map_err(|e| StoreError::RuntimeError(e.to_string()))?;
-        let (_, result) = runner
-            .fetch_novel_info(url)
-            .await
-            .map_err(|e| StoreError::RuntimeError(e.to_string()))?;
-        result.map_err(|wit_err| {
-            let chain = wit_err
-                .frames
-                .iter()
-                .map(|f| f.message.as_str())
-                .collect::<Vec<_>>()
-                .join(": ");
-            StoreError::RuntimeError(format!("Extension error: {}", chain))
-        })
-    }
-
-    /// Find, install if needed, and use the appropriate extension to fetch chapter content.
-    ///
-    /// Returns an error if no extension handles the URL or if the extension call fails.
-    pub async fn fetch_chapter(
-        &mut self,
-        engine: &quelle_engine::ExtensionEngine,
-        url: &str,
-    ) -> crate::error::Result<quelle_types::ChapterContent> {
-        let installed = self.find_and_install_for_url(url).await?;
-        let wasm_bytes = self
-            .registry
-            .get_extension_wasm_bytes(&installed.id)
-            .await?;
-        let runner = engine
-            .new_runner_from_bytes(&wasm_bytes)
-            .await
-            .map_err(|e| StoreError::RuntimeError(e.to_string()))?;
-        let (_, result) = runner
-            .fetch_chapter(url)
-            .await
-            .map_err(|e| StoreError::RuntimeError(e.to_string()))?;
-        result.map_err(|wit_err| {
-            let chain = wit_err
-                .frames
-                .iter()
-                .map(|f| f.message.as_str())
-                .collect::<Vec<_>>()
-                .join(": ");
-            StoreError::RuntimeError(format!("Extension error: {}", chain))
-        })
     }
 
     // Installation Operations

--- a/crates/store/src/manager/core.rs
+++ b/crates/store/src/manager/core.rs
@@ -244,7 +244,7 @@ impl StoreManager {
     pub async fn search_novels_with_installed_extensions(
         &self,
         query: &SearchQuery,
-    ) -> Result<Vec<quelle_engine::bindings::quelle::extension::novel::BasicNovel>> {
+    ) -> Result<Vec<quelle_types::BasicNovel>> {
         use quelle_engine::bindings::quelle::extension::novel::{
             AppliedFilter, ComplexSearchQuery, FilterValue, SimpleSearchQuery,
         };

--- a/crates/store/src/manager/core.rs
+++ b/crates/store/src/manager/core.rs
@@ -555,6 +555,86 @@ impl StoreManager {
         Ok(None)
     }
 
+    /// Internal helper: find and, if necessary, install an extension for the given URL.
+    async fn find_and_install_for_url(
+        &mut self,
+        url: &str,
+    ) -> crate::error::Result<crate::models::InstalledExtension> {
+        let (extension_id, _) = self.find_extension_for_url(url).await?.ok_or_else(|| {
+            StoreError::RuntimeError(format!("No extension found for URL: {}", url))
+        })?;
+
+        if let Some(installed) = self.get_installed(&extension_id).await? {
+            return Ok(installed);
+        }
+
+        self.install(&extension_id, None, None).await
+    }
+
+    /// Find, install if needed, and use the appropriate extension to fetch novel metadata.
+    ///
+    /// Returns an error if no extension handles the URL or if the extension call fails.
+    pub async fn fetch_novel(
+        &mut self,
+        engine: &quelle_engine::ExtensionEngine,
+        url: &str,
+    ) -> crate::error::Result<quelle_types::Novel> {
+        let installed = self.find_and_install_for_url(url).await?;
+        let wasm_bytes = self
+            .registry
+            .get_extension_wasm_bytes(&installed.id)
+            .await?;
+        let runner = engine
+            .new_runner_from_bytes(&wasm_bytes)
+            .await
+            .map_err(|e| StoreError::RuntimeError(e.to_string()))?;
+        let (_, result) = runner
+            .fetch_novel_info(url)
+            .await
+            .map_err(|e| StoreError::RuntimeError(e.to_string()))?;
+        result.map_err(|wit_err| {
+            let chain = wit_err
+                .frames
+                .iter()
+                .map(|f| f.message.as_str())
+                .collect::<Vec<_>>()
+                .join(": ");
+            StoreError::RuntimeError(format!("Extension error: {}", chain))
+        })
+    }
+
+    /// Find, install if needed, and use the appropriate extension to fetch chapter content.
+    ///
+    /// Returns an error if no extension handles the URL or if the extension call fails.
+    pub async fn fetch_chapter(
+        &mut self,
+        engine: &quelle_engine::ExtensionEngine,
+        url: &str,
+    ) -> crate::error::Result<quelle_types::ChapterContent> {
+        let installed = self.find_and_install_for_url(url).await?;
+        let wasm_bytes = self
+            .registry
+            .get_extension_wasm_bytes(&installed.id)
+            .await?;
+        let runner = engine
+            .new_runner_from_bytes(&wasm_bytes)
+            .await
+            .map_err(|e| StoreError::RuntimeError(e.to_string()))?;
+        let (_, result) = runner
+            .fetch_chapter(url)
+            .await
+            .map_err(|e| StoreError::RuntimeError(e.to_string()))?;
+        result.map_err(|wit_err| {
+            let chain = wit_err
+                .frames
+                .iter()
+                .map(|f| f.message.as_str())
+                .collect::<Vec<_>>()
+                .join(": ");
+            StoreError::RuntimeError(format!("Extension error: {}", chain))
+        })
+    }
+
     // Installation Operations
 
     /// Install an extension from the best available store

--- a/crates/store/src/registry/core.rs
+++ b/crates/store/src/registry/core.rs
@@ -648,7 +648,7 @@ mod tests {
         match LocalInstallRegistry::new_with_defaults().await {
             Ok(reg) => {
                 let installed = reg.list_installed().await.unwrap();
-                assert!(installed.len() >= 0); // trivially true; proves no panic
+                let _ = installed; // proves no panic
             }
             Err(_) => {
                 // Acceptable on systems where the data directory is unavailable
@@ -683,12 +683,7 @@ mod tests {
 
     #[test]
     fn test_trait_is_implementation_agnostic() {
-        // Verify that the trait can be used as a trait object
-        fn verify_generic_interface(_registry: &dyn InstallRegistry) {}
-
-        let dir = TempDir::new().unwrap();
-        // We can't easily construct without async here, so just verify the
-        // function accepts &dyn InstallRegistry — this is a compile-time check.
-        let _ = dir;
+        // Verify that the trait can be used as a trait object — compile-time check only.
+        let _: fn(&dyn InstallRegistry) = |_registry| {};
     }
 }

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "quelle_types"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -43,12 +43,14 @@ pub struct Metadata {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
 pub enum Namespace {
     Dc,
     Opf,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
 pub enum NovelStatus {
     Ongoing,
     Hiatus,

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -1,0 +1,81 @@
+//! Domain types for the Quelle project.
+//!
+//! This crate provides plain Rust structs and enums representing the core
+//! domain types used across the workspace. It has no dependency on Wasmtime
+//! or any other heavyweight crate — only `serde` for serialization support.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Novel {
+    pub url: String,
+    pub authors: Vec<String>,
+    pub title: String,
+    pub cover: Option<String>,
+    pub description: Vec<String>,
+    pub volumes: Vec<Volume>,
+    pub metadata: Vec<Metadata>,
+    pub status: NovelStatus,
+    pub langs: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Volume {
+    pub name: String,
+    pub index: i32,
+    pub chapters: Vec<Chapter>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Chapter {
+    pub title: String,
+    pub index: i32,
+    pub url: String,
+    pub updated_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Metadata {
+    pub name: String,
+    pub value: String,
+    pub ns: Namespace,
+    pub others: Vec<(String, String)>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Namespace {
+    Dc,
+    Opf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum NovelStatus {
+    Ongoing,
+    Hiatus,
+    Completed,
+    Stub,
+    Dropped,
+    Unknown,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChapterContent {
+    pub data: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BasicNovel {
+    pub title: String,
+    pub cover: Option<String>,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchResult {
+    pub novels: Vec<BasicNovel>,
+    pub total_count: Option<u32>,
+    pub current_page: u32,
+    pub total_pages: Option<u32>,
+    pub has_next_page: bool,
+    pub has_previous_page: bool,
+}


### PR DESCRIPTION
This pull request refactors how the CLI fetches novels and chapters, decoupling extension management (finding and installing the right extension for a URL) from content execution (running the extension to fetch data). The logic for fetching novels and chapters is now centralized in new helper functions in `engine.rs`, leading to cleaner and more maintainable command handlers. Additionally, novel and chapter lookups in storage have been improved for reliability and performance.

**Core refactoring and architectural improvements:**

* Introduced new async helpers `fetch_novel` and `fetch_chapter` in `crates/cli/src/engine.rs` to encapsulate the logic for finding/installing the correct extension and running it to fetch content, replacing the previous pattern of manual extension lookup and invocation throughout the CLI.
* Removed now-redundant helper functions (`find_extension_for_url`, `find_and_install_extension_for_url`, `fetch_novel_with_extension`, `fetch_chapter_with_extension`) from `crates/cli/src/commands/fetch.rs`, with all call sites migrated to use the new engine helpers. [[1]](diffhunk://#diff-b68a4f251da84cdb4ed51cfcf893f3de821062ae0dbba27a8f0c4aa614ecaf12L423-L513) [[2]](diffhunk://#diff-b68a4f251da84cdb4ed51cfcf893f3de821062ae0dbba27a8f0c4aa614ecaf12L92-R95) [[3]](diffhunk://#diff-b68a4f251da84cdb4ed51cfcf893f3de821062ae0dbba27a8f0c4aa614ecaf12L176-R175) [[4]](diffhunk://#diff-b68a4f251da84cdb4ed51cfcf893f3de821062ae0dbba27a8f0c4aa614ecaf12L286-L300) [[5]](diffhunk://#diff-b68a4f251da84cdb4ed51cfcf893f3de821062ae0dbba27a8f0c4aa614ecaf12L314-L321) [[6]](diffhunk://#diff-b68a4f251da84cdb4ed51cfcf893f3de821062ae0dbba27a8f0c4aa614ecaf12L346-R268) [[7]](diffhunk://#diff-0cfac2507e380fbde0887d2d593c7ad6eb37de88c112f754cc4bd8aeadb65635L418-R419) [[8]](diffhunk://#diff-0cfac2507e380fbde0887d2d593c7ad6eb37de88c112f754cc4bd8aeadb65635L455-R454) [[9]](diffhunk://#diff-0cfac2507e380fbde0887d2d593c7ad6eb37de88c112f754cc4bd8aeadb65635L596-L600)

**Storage and lookup improvements:**

* Replaced title-based novel lookups with direct ID lookups via new `find_novel_id_by_url` method, improving reliability and performance when associating chapters and novels. This affects chapter fetch/save logic and novel resolution. [[1]](diffhunk://#diff-b68a4f251da84cdb4ed51cfcf893f3de821062ae0dbba27a8f0c4aa614ecaf12L176-R175) [[2]](diffhunk://#diff-b68a4f251da84cdb4ed51cfcf893f3de821062ae0dbba27a8f0c4aa614ecaf12L286-L300) [[3]](diffhunk://#diff-937217df13f7ea76ab0e5b02a5dabcc4e4b51aa695dc085c89e6333509d93683L33-R34)

**Dependency and type updates:**

* Added `quelle_types` as a dependency in the CLI and workspace, and updated imports to use types from this crate (e.g., `BasicNovel`). [[1]](diffhunk://#diff-d43310c69dbd64dbe201466da69d7a4f3bd4662bbed8dd7fbab668709553627eL17-R21) [[2]](diffhunk://#diff-61feddd416ac1b045de89f48d5e44b3d6d65bb714b6329a90470754688003683L4-R5) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R19)

**Other minor cleanups:**

* Removed unused imports and streamlined error handling in affected files. [[1]](diffhunk://#diff-b68a4f251da84cdb4ed51cfcf893f3de821062ae0dbba27a8f0c4aa614ecaf12L14-R14) [[2]](diffhunk://#diff-b68a4f251da84cdb4ed51cfcf893f3de821062ae0dbba27a8f0c4aa614ecaf12L158-R121)

These changes collectively make the CLI codebase more modular, easier to maintain, and less error-prone by centralizing extension execution logic and improving storage lookups.